### PR TITLE
feat: 公式マルチシード再現と CI（pytest + repro-smoke）

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,5 +1,5 @@
-# F-1 / BLG-004: run static analysis on every PR and on pushes to protected branches.
-# PR1 scope: ruff only. pytest and repro-smoke are added when tda_ml/ and tests/ land (later PRs).
+# F-1 / BLG-004: static analysis, tests, and a lightweight repro smoke on every PR and on pushes
+# to protected branches. (Workflow filename kept as ruff.yml for existing branch-protection hooks.)
 # Add this workflow as a required status check in branch protection to block merges on failure.
 name: Ruff
 
@@ -42,3 +42,18 @@ jobs:
 
       - name: Ruff check (repo root; F-1 canonical command)
         run: uv run ruff check .
+
+      - name: Pytest
+        run: uv run pytest -q
+
+      # One epoch, one seed, mahalanobis only (README / REPRODUCIBILITY.md). Fresh out-base per run.
+      - name: Repro smoke (run_backend_multiseed)
+        run: |
+          set -euo pipefail
+          OUT="outputs/ci_smoke_${GITHUB_RUN_ID:-local}"
+          uv run python experiments/run_backend_multiseed.py \
+            --base-config reproduce \
+            --epochs 1 \
+            --seeds 42 \
+            --backends mahalanobis \
+            --out-base "$OUT"

--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ The full official command (50 epochs × five seeds × two backends) is **not** e
 - Runtime and numeric behavior can vary by `device`, `thread`, and `dtype`; effective values should be logged per run.
 - External implementations are reference-only and are not redistributed in this repository.
 - Scripts under `tda_ml/experiments/` are **non-official** and require your own checkpoints (see `configs/README.md`).
+- `run_backend_multiseed.py` multiseed backend comparison is **not** a pure distance-backend-only ablation; it compares full training pipelines, not an isolated backend switch.
+- For topological loss, **`mahalanobis`** can incorporate predicted **outlier-probability weighting** in the distance matrix; **`ellphi`** does not (geometry-only distances; `probs` ignored).
+- Read outcomes as **two full pipelines** under the same schedule and config surface, not as isolating distance-backend effects alone.
 
 ### Backend comparison: outlier-probability weighting
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ The full official command (50 epochs × five seeds × two backends) is **not** e
 - External implementations are reference-only and are not redistributed in this repository.
 - Scripts under `tda_ml/experiments/` are **non-official** and require your own checkpoints (see `configs/README.md`).
 
+### Backend comparison: outlier-probability weighting
+
+For **topological loss**, the batched distance matrix is built per `model.topology_loss.distance_backend`. With **`mahalanobis`**, the implementation can incorporate **predicted outlier probabilities** when forming pairwise distances (see `tda_ml.topology.compute_anisotropic_distance_matrix`). With **`ellphi`**, tangency distances are computed from ellipse geometry only; **probability-based weighting is not implemented** and `probs` are ignored (a warning is emitted once per process; see `tda_ml.distance_backend.compute_distance_matrix_batch`). Hyperparameters in `configs/reproduce.yaml` are shared across backends, but **the induced metric for topological loss is not identical across backends** by design: the intended read is a reproducible pipeline comparison (same data, schedule, and config surface), not a claim that both backends optimize the exact same weighted distance objective. Elliptic contact distances are left as defined by `ellphi`; no synthetic “prob-equivalent” weighting is applied on the ellphi path.
+
 ## License / Attribution
 
 This project is licensed under the MIT License. See `LICENSE`.

--- a/REPRODUCIBILITY.md
+++ b/REPRODUCIBILITY.md
@@ -13,13 +13,11 @@
 - **依存関係**: **uv** で管理。リポジトリのルートで:
 
   ```bash
-  git submodule update --init --recursive
-  test -f pytorch-topological/pyproject.toml || \
-    git clone --depth 1 https://github.com/aidos-lab/pytorch-topological.git pytorch-topological
+  ./scripts/ensure_pytorch_topological.sh
   uv sync --all-groups   # ローカル検証用に dev（pytest, ruff）を含める
   ```
 
-  `torch_topological` は **`pytorch-topological/` の path 依存**であり、このリポジトリの既定クローンには含まれない。上記 `git clone` は CI と同じ不足時の取得手順である。
+  `torch_topological` は **`pytorch-topological/` の path 依存**（`pyproject.toml`）であり、通常の `git clone` だけではディレクトリが揃いません。コミットは **`third_party/pytorch_topological.ref`** に固定し、**`scripts/ensure_pytorch_topological.sh`** がその ref に checkout します（CI と同じ）。サブモジュール gitlink がある場合は `git submodule update --init --recursive` のあとも ensure で pin を検証してください。詳細は `third_party/README.md`。
 
 - **PyTorch / CUDA**: 数値結果はデバイスや dtype によって変わり得ます。`tda_ml/main.py` の学習ループを使う場合、有効な設定は各実行の `logs/` 配下の `runtime_profile.json` などに記録されます。
 
@@ -51,6 +49,10 @@ uv run python experiments/run_backend_multiseed.py \
 再開の挙動、ロックファイル、CSV の意味は `README.md` に書いてあります。
 
 ### バックエンド比較と outlier 確率の重み（非対称）
+
+- `run_backend_multiseed.py` のマルチシード・バックエンド比較は、**距離バックエンドだけを切り替えた純粋な ablation ではありません**（学習パイプライン全体の比較です）。
+- 位相損失では **`mahalanobis`** が outlier **確率による重み付け**を距離行列に織り込める一方、**`ellphi`** では **未実装**で `probs` は使われません。
+- 結果は **同一スケジュール・同一設定表面**（典型: `configs/reproduce.yaml`）上の **2 本のフルパイプライン**として読み、距離実装だけの効果に還元しないでください。
 
 位相損失用の距離行列は `model.topology_loss.distance_backend` ごとに別定義です。**`mahalanobis`** では、学習で予測した **outlier 確率 `probs`** を距離の重み付けに織り込めます（`tda_ml.topology.compute_anisotropic_distance_matrix`）。**`ellphi`** では楕円の接触距離のみを用い、**確率に基づく重み付けは未実装のため `probs` は使われません**（初回のみ `UserWarning` が出ます。実装は `tda_ml.distance_backend.compute_distance_matrix_batch`）。
 

--- a/REPRODUCIBILITY.md
+++ b/REPRODUCIBILITY.md
@@ -1,0 +1,87 @@
+# 再現性ガイド
+
+この文書は **読者向け** です。実験の再現手順、データと成果物の置き場所、図がコードのどこに対応するかをまとめています。内部手順・監査メモなど（従来 `docs/` に置いていたもの）は **この公開リポジトリの git ツリーには含めません**（ローカルや別管理で保持してください）。
+
+## リポジトリに含まれる範囲（目安）
+
+- **含む:** `tda_ml/`、**`configs/` 直下の正本 YAML**（`base.yaml` と `reproduce` / `dev` / `prod` / `test_fast` の各ファイル）、`tests/`、追跡されている `scripts/`、`experiments/run_backend_multiseed.py`、および `README.md` / `REPRODUCIBILITY.md` / `pyproject.toml` / `uv.lock` / `LICENSE` / `CITATION.cff` などのメタデータ。
+- **含めない:** `docs/` 以下、`configs/archive/`（履歴用 YAML を置く場合は **ローカルのみ**）、`outputs/`、`data/` など。`load_config("archive/...")` は、手元に `configs/archive/*.yaml` を置いた場合にのみ使えます。
+
+## 環境
+
+- **Python**: `.python-version` を参照（現状 3.12）。
+- **依存関係**: **uv** で管理。リポジトリのルートで:
+
+  ```bash
+  git submodule update --init --recursive
+  test -f pytorch-topological/pyproject.toml || \
+    git clone --depth 1 https://github.com/aidos-lab/pytorch-topological.git pytorch-topological
+  uv sync --all-groups   # ローカル検証用に dev（pytest, ruff）を含める
+  ```
+
+  `torch_topological` は **`pytorch-topological/` の path 依存**であり、このリポジトリの既定クローンには含まれない。上記 `git clone` は CI と同じ不足時の取得手順である。
+
+- **PyTorch / CUDA**: 数値結果はデバイスや dtype によって変わり得ます。`tda_ml/main.py` の学習ループを使う場合、有効な設定は各実行の `logs/` 配下の `runtime_profile.json` などに記録されます。
+
+## データ（MNIST）
+
+- MNIST は git にコミットしません（`data/` は無視対象）。
+- 初回の学習またはデータセットアクセス時に、`torchvision` 経由で **`./data`** 以下にダウンロードされます（`configs/reproduce.yaml` を前提とした設定が典型です）。
+- 初回はインターネットに到達できるようにするか、キャッシュ済みの MNIST を自分で `./data` に置いてください。
+- 設定 YAML の役割分担は **`configs/README.md`**（正本 5 本）を参照。旧設定はローカルで `configs/archive/` に置けるが、公開クローンには同梱されない。
+
+## チェックポイントと実行出力
+
+- `experiments/run_backend_multiseed.py` が内部で読み込む **`tda_ml/main.py`** の学習処理により、実行ごとのディレクトリ以下に成果物が書き出されます（README の「Expected artifacts」参照）。典型例は `logs/metrics.csv`、`logs/runtime_profile.json`、`best_model.pth`、可視化が有効なら `images/` などです。
+- **`outputs/`** は git の対象外です。論文用に実行ツリーを保存する場合は、原稿や付録で **コミットハッシュ・シード・使用した設定名** とあわせてパスを示すと追跡しやすいです。`progress_summary.csv` には絶対パスが入るため、共有時のプライバシーに注意してください。
+
+## 数値再現の公式手順
+
+**公式**のマルチシード・バックエンド比較は次のとおりです。
+
+```bash
+uv run python experiments/run_backend_multiseed.py \
+  --base-config reproduce \
+  --epochs 50 \
+  --seeds 42 123 456 789 1024 \
+  --backends mahalanobis ellphi \
+  --out-base outputs/backend_compare
+```
+
+再開の挙動、ロックファイル、CSV の意味は `README.md` に書いてあります。
+
+### バックエンド比較と outlier 確率の重み（非対称）
+
+位相損失用の距離行列は `model.topology_loss.distance_backend` ごとに別定義です。**`mahalanobis`** では、学習で予測した **outlier 確率 `probs`** を距離の重み付けに織り込めます（`tda_ml.topology.compute_anisotropic_distance_matrix`）。**`ellphi`** では楕円の接触距離のみを用い、**確率に基づく重み付けは未実装のため `probs` は使われません**（初回のみ `UserWarning` が出ます。実装は `tda_ml.distance_backend.compute_distance_matrix_batch`）。
+
+したがって、`run_backend_multiseed.py` で同じ YAML を回しても、**位相損失が見ている距離空間はバックエンド間で同一ではありません**。ここでは「同一のデータ・スケジュール・設定表面での再現パイプライン比較」を意図しており、**両バックエンドが数学的に完全に同型の重み付き距離目的関数を共有する**という読み方はしません。`ellphi` 側に Mahalanobis の確率重みに相当する項を無理に足す予定はなく、比較の解釈は本節および `README.md` の英語節（*Backend comparison: outlier-probability weighting*）に従ってください。
+
+## 図・定性出力
+
+`docs/paper/` 以下の LaTeX の **すべての図を一括で出す単一スクリプトはありません**。原稿専用のアセットもあります。下の表は **コードに近い** 図の流れを示すものです。論文の図を増やしたら表も追記してください。
+
+| 種類 | スクリプト / 場所 | 典型出力 |
+|------|-------------------|----------|
+| 学習中のスナップショット（楕円・点） | `tda_ml.trainer` → `tda_ml.visualization.visualize` | `<run_dir>/images/`、`result_epoch_*.png` を含むファイル名 |
+| PD アニメ（任意 extra） | `tda_ml/reproduce_pd_animation.py`（`pyproject` の optional `repro-pd-animation` 参照） | `experiments/repro_pd_animation_final/frames/` 付近（スクリプトが `image_dir` を設定） |
+| ノイズ感度プロット | `tda_ml/experiments/run_noise_sensitivity.py` | `outputs/metrics_vs_noise_level.png` |
+| クラスタリングベンチマーク図 | `tda_ml/experiments/clustering_benchmark.py`（`--checkpoint` 必須） | `--output` で指定（既定 `outputs/clustering_benchmark.png`） |
+| ロバストネススイープの図 | `tda_ml/robustness_sweep.py` | `important_results/robustness_*.png` |
+| 学習 PNG の分割・後処理 | `tda_ml/split_results_images.py` | ユーザー指定の `--image_dir` / `--output_dir` |
+| 静的な論文用アセット | `docs/paper/` 以下の LaTeX（`\includegraphics` のパスは各 `.tex` を参照） | 論文ビルドが参照する PNG/PDF（ローカル生成のこともあり、常に git に無いとは限らない） |
+
+楕円描画は `tda_ml/visualization.py` と `tda_ml/geometry.py`（パラメータ → 共分散 → 描画）を参照してください。内部用の長い数式メモは公開 git には含めません。
+
+## 自動テスト
+
+ローカルでは:
+
+```bash
+uv run pytest
+```
+
+PR および **`main` と `feature/**` への push** のたびに、CI では **ruff**、**pytest**、軽量な **再現スモーク**（`experiments/run_backend_multiseed.py` を `--epochs 1`・1 seed・`mahalanobis` で実行）が走ります。**50 epoch × 5 seed × 2 backend の本番コマンドは CI では実行しません。**
+
+## 論文提出時のスナップショット
+
+論文投稿時は、提出結果と一致する **git コミットを固定**し、`CITATION.cff` およびリポジトリ URL を、正本の組織リポジトリ（公式が `uda-lab/TDA-ML` のときはそれ）と揃えて引用してください。

--- a/experiments/run_backend_multiseed.py
+++ b/experiments/run_backend_multiseed.py
@@ -70,7 +70,13 @@ PROGRESS_HEADER = [
 REQUIRED_METRIC_COLUMNS = {"val_mcc", "val_recall", "val_loss"}
 
 
-def _parse_finite_float(row: dict[str, str], key: str, metrics_path: str) -> float:
+def _parse_float(
+    row: dict[str, str],
+    key: str,
+    metrics_path: str,
+    *,
+    require_finite: bool = True,
+) -> float:
     if key not in row:
         raise RuntimeError(f"Missing column '{key}' in metrics file: {metrics_path}")
     try:
@@ -79,8 +85,13 @@ def _parse_finite_float(row: dict[str, str], key: str, metrics_path: str) -> flo
         raise RuntimeError(
             f"Failed to parse '{key}' as float in metrics file: {metrics_path}"
         ) from e
-    if not math.isfinite(value):
+    if require_finite and not math.isfinite(value):
         raise RuntimeError(f"Non-finite value for '{key}' in metrics file: {metrics_path}")
+    if not require_finite and not math.isfinite(value):
+        print(
+            f"[WARN] Non-finite value for '{key}' in metrics file: {metrics_path}; "
+            "keeping value for summary output."
+        )
     return value
 
 
@@ -100,14 +111,16 @@ def parse_metrics_csv(metrics_path: str) -> dict[str, float]:
 
     final = rows[-1]
     # Tie-break: first epoch row attaining max val_mcc (stable with max()).
-    best = max(rows, key=lambda r: _parse_finite_float(r, "val_mcc", metrics_path))
+    best = max(rows, key=lambda r: _parse_float(r, "val_mcc", metrics_path))
     return {
-        "final_val_mcc": _parse_finite_float(final, "val_mcc", metrics_path),
-        "final_val_recall": _parse_finite_float(final, "val_recall", metrics_path),
-        "final_val_loss": _parse_finite_float(final, "val_loss", metrics_path),
-        "best_val_mcc": _parse_finite_float(best, "val_mcc", metrics_path),
-        "best_val_recall": _parse_finite_float(best, "val_recall", metrics_path),
-        "best_val_loss": _parse_finite_float(best, "val_loss", metrics_path),
+        "final_val_mcc": _parse_float(final, "val_mcc", metrics_path),
+        "final_val_recall": _parse_float(final, "val_recall", metrics_path),
+        "final_val_loss": _parse_float(
+            final, "val_loss", metrics_path, require_finite=False
+        ),
+        "best_val_mcc": _parse_float(best, "val_mcc", metrics_path),
+        "best_val_recall": _parse_float(best, "val_recall", metrics_path),
+        "best_val_loss": _parse_float(best, "val_loss", metrics_path, require_finite=False),
     }
 
 

--- a/experiments/run_backend_multiseed.py
+++ b/experiments/run_backend_multiseed.py
@@ -1,0 +1,387 @@
+"""
+Multi-seed backend comparison driver (experimental protocol wrapper).
+
+Protocol (defaults can be overridden via CLI):
+- YAML base config loaded by name (default ``reproduce``; path resolved by
+  ``tda_ml.config.load_config`` together with the rest of the training stack).
+- Training runs sequentially via ``tda_ml.main.main`` with overrides for ``epochs``,
+  ``data.seed``, ``model.topology_loss.distance_backend``, and output root
+  ``outputs.base_dir``.
+
+Outputs (under ``--out-base``, default ``outputs/backend_compare``):
+- ``progress_summary.csv``: one row per completed (backend, seed, epochs).
+- ``backend_stats.csv``: per-backend mean and variability of MCC across seeds.
+
+Metric definitions (from each run's ``logs/metrics.csv``, one row per epoch):
+- ``final_*``: values from the **last** epoch row (training order in the file).
+- ``best_*``: values from the epoch row with **maximum** ``val_mcc``. If several
+  epochs tie for the maximum, Python's ``max`` keeps the **first** such row in
+  file order. ``best_val_loss`` and ``best_val_recall`` are taken from that same
+  row (they are **not** the loss/recall at an argmin-loss epoch).
+
+Aggregation in ``backend_stats.csv`` (over distinct seeds per backend):
+- ``mean_*``: arithmetic mean across completed runs.
+- ``std_*``: **sample** standard deviation with divisor ``n - 1`` (same as
+  ``statistics.stdev``). For ``n_completed < 2``, standard deviation is written
+  as ``0.0`` as a placeholder (cross-seed variability is undefined); interpret
+  using ``n_completed``.
+
+Concurrency / filesystem:
+- A lock file under ``--out-base`` serializes this driver for one output tree.
+  Do not run two instances sharing the same ``--out-base``.
+- Run directory detection uses new directories matching ``config_id_*`` before
+  and after each training call; **parallel** runs with the same ``config_id``
+  prefix can collide. Intended use is **one sequential process** per ``out-base``.
+
+Privacy / version control:
+- ``progress_summary.csv`` stores absolute ``run_dir`` paths; avoid committing
+  filled CSVs from personal machines if paths must stay private.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import glob
+import math
+import os
+from contextlib import contextmanager
+from pathlib import Path
+from statistics import mean, stdev
+from typing import Any
+
+from tda_ml.main import main as train_main
+from tda_ml.config import deep_update, load_config
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+PROGRESS_HEADER = [
+    "backend",
+    "seed",
+    "epochs",
+    "run_dir",
+    "best_val_mcc",
+    "best_val_recall",
+    "best_val_loss",
+    "final_val_mcc",
+    "final_val_recall",
+    "final_val_loss",
+]
+REQUIRED_METRIC_COLUMNS = {"val_mcc", "val_recall", "val_loss"}
+
+
+def _parse_finite_float(row: dict[str, str], key: str, metrics_path: str) -> float:
+    if key not in row:
+        raise RuntimeError(f"Missing column '{key}' in metrics file: {metrics_path}")
+    try:
+        value = float(row[key])
+    except ValueError as e:
+        raise RuntimeError(
+            f"Failed to parse '{key}' as float in metrics file: {metrics_path}"
+        ) from e
+    if not math.isfinite(value):
+        raise RuntimeError(f"Non-finite value for '{key}' in metrics file: {metrics_path}")
+    return value
+
+
+def parse_metrics_csv(metrics_path: str) -> dict[str, float]:
+    """Parse epoch-wise metrics; see module docstring for *best* vs *final*."""
+    with open(metrics_path, "r", newline="") as f:
+        reader = csv.DictReader(f)
+        fieldnames = set(reader.fieldnames or [])
+        missing = REQUIRED_METRIC_COLUMNS - fieldnames
+        if missing:
+            raise RuntimeError(
+                f"Missing required columns {sorted(missing)} in metrics file: {metrics_path}"
+            )
+        rows = list(reader)
+    if not rows:
+        raise RuntimeError(f"No rows found in metrics file: {metrics_path}")
+
+    final = rows[-1]
+    # Tie-break: first epoch row attaining max val_mcc (stable with max()).
+    best = max(rows, key=lambda r: _parse_finite_float(r, "val_mcc", metrics_path))
+    return {
+        "final_val_mcc": _parse_finite_float(final, "val_mcc", metrics_path),
+        "final_val_recall": _parse_finite_float(final, "val_recall", metrics_path),
+        "final_val_loss": _parse_finite_float(final, "val_loss", metrics_path),
+        "best_val_mcc": _parse_finite_float(best, "val_mcc", metrics_path),
+        "best_val_recall": _parse_finite_float(best, "val_recall", metrics_path),
+        "best_val_loss": _parse_finite_float(best, "val_loss", metrics_path),
+    }
+
+
+def ensure_csv_header(path: str, header: list[str]) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    if not os.path.exists(path):
+        with open(path, "w", newline="") as f:
+            writer = csv.writer(f)
+            writer.writerow(header)
+        return
+
+    with open(path, "r", newline="") as f:
+        reader = csv.reader(f)
+        existing = next(reader, None)
+
+    if existing is None:
+        with open(path, "w", newline="") as f:
+            writer = csv.writer(f)
+            writer.writerow(header)
+        return
+
+    if existing != header:
+        raise RuntimeError(
+            "Unexpected CSV header in progress file. "
+            f"Expected={header}, Found={existing}. "
+            "Use a fresh --out-base directory or fix the CSV manually."
+        )
+
+
+def append_row(path: str, row: list[Any]) -> None:
+    with open(path, "a", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(row)
+
+
+@contextmanager
+def out_base_lock(out_base: str):
+    lock_path = os.path.join(out_base, ".run_backend_multiseed.lock")
+    try:
+        fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+    except FileExistsError as e:
+        raise RuntimeError(
+            "Another run_backend_multiseed process appears to be using this --out-base. "
+            "Use a different --out-base or wait for the running process to finish."
+        ) from e
+
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(str(os.getpid()))
+        yield
+    finally:
+        try:
+            os.remove(lock_path)
+        except FileNotFoundError:
+            pass
+
+
+def read_progress(path: str) -> list[dict[str, str]]:
+    if not os.path.exists(path):
+        return []
+    with open(path, "r", newline="") as f:
+        rows = list(csv.DictReader(f))
+    valid_rows: list[dict[str, str]] = []
+    for idx, row in enumerate(rows, start=2):
+        try:
+            int(row["seed"])
+            int(row["epochs"])
+            float(row["best_val_mcc"])
+            float(row["final_val_mcc"])
+        except (KeyError, ValueError):
+            print(f"[WARN] skip malformed progress row at line={idx}: {row}")
+            continue
+        valid_rows.append(row)
+    return valid_rows
+
+
+def sample_std_over_seeds(values: list[float]) -> float:
+    """Sample standard deviation (divisor n-1); 0.0 if n < 2 (placeholder)."""
+    if len(values) < 2:
+        return 0.0
+    return stdev(values)
+
+
+def write_backend_stats(progress_csv: str, stats_csv: str) -> None:
+    """Rewrite backend_stats.csv from progress_summary (deduped); see module docstring."""
+    rows = read_progress(progress_csv)
+    # Deduplicate retries/reruns: keep the last observed row per run key.
+    unique_by_run: dict[tuple[str, int, int], dict[str, str]] = {}
+    for row in rows:
+        key = (row["backend"], int(row["seed"]), int(row["epochs"]))
+        unique_by_run[key] = row
+    rows = list(unique_by_run.values())
+
+    by_backend: dict[str, list[dict[str, str]]] = {}
+    for r in rows:
+        by_backend.setdefault(r["backend"], []).append(r)
+
+    header = [
+        "backend",
+        "n_completed",
+        "mean_best_val_mcc",
+        "std_best_val_mcc",
+        "mean_final_val_mcc",
+        "std_final_val_mcc",
+    ]
+    with open(stats_csv, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(header)
+        for backend, rs in sorted(by_backend.items()):
+            n = len(rs)
+            best_vals = [float(x["best_val_mcc"]) for x in rs]
+            final_vals = [float(x["final_val_mcc"]) for x in rs]
+            best_std = sample_std_over_seeds(best_vals)
+            final_std = sample_std_over_seeds(final_vals)
+            writer.writerow(
+                [
+                    backend,
+                    n,
+                    mean(best_vals),
+                    best_std,
+                    mean(final_vals),
+                    final_std,
+                ]
+            )
+
+
+def detect_new_run_dir(base_dir: str, prefix: str, before: set[str]) -> str:
+    """Infer new run directory after train_main; sequential runs only (see module doc)."""
+    after = set(glob.glob(os.path.join(base_dir, f"{prefix}_*")))
+    created = sorted(after - before)
+    if created:
+        return created[-1]
+    # Fallback if directory existed before timing race.
+    candidates = sorted(after)
+    if not candidates:
+        raise RuntimeError(f"Could not detect run directory for prefix={prefix}")
+    return candidates[-1]
+
+
+def run_one(
+    base_config_name: str,
+    backend: str,
+    seed: int,
+    epochs: int,
+    out_base: str,
+    progress_csv: str,
+) -> None:
+    cfg = load_config(base_config_name, project_root=REPO_ROOT)
+    config_id = f"backend_{backend}_seed{seed}"
+    topo_cfg = cfg.get("model", {}).get("topology_loss", {})
+    ellphi_diff = bool(topo_cfg.get("ellphi_differentiable", True))
+
+    overrides = {
+        "meta": {"config_id": config_id},
+        "training": {"epochs": epochs},
+        "data": {"seed": seed},
+        "model": {
+            "topology_loss": {
+                "distance_backend": backend,
+                "ellphi_differentiable": ellphi_diff,
+            }
+        },
+        "outputs": {"base_dir": out_base},
+    }
+    cfg = deep_update(cfg, overrides)
+
+    before = set(glob.glob(os.path.join(out_base, f"{config_id}_*")))
+    print(f"[START] backend={backend} seed={seed} epochs={epochs}")
+    train_main(config=cfg)
+    run_dir = detect_new_run_dir(out_base, config_id, before)
+    metrics_path = os.path.join(run_dir, "logs", "metrics.csv")
+    metrics = parse_metrics_csv(metrics_path)
+
+    append_row(
+        progress_csv,
+        [
+            backend,
+            seed,
+            epochs,
+            run_dir,
+            metrics["best_val_mcc"],
+            metrics["best_val_recall"],
+            metrics["best_val_loss"],
+            metrics["final_val_mcc"],
+            metrics["final_val_recall"],
+            metrics["final_val_loss"],
+        ],
+    )
+    print(
+        "[DONE] "
+        f"backend={backend} seed={seed} best_val_mcc={metrics['best_val_mcc']:.4f} "
+        f"final_val_mcc={metrics['final_val_mcc']:.4f}"
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description=(
+            "Run multi-seed backend comparison and aggregate metrics. "
+            "See module docstring for metric definitions and aggregation."
+        )
+    )
+    p.add_argument("--base-config", type=str, default="reproduce")
+    p.add_argument("--epochs", type=int, default=50)
+    p.add_argument("--seeds", type=int, nargs="+", default=[42, 123, 456, 789, 1024])
+    p.add_argument(
+        "--backends",
+        type=str,
+        nargs="+",
+        default=["mahalanobis", "ellphi"],
+        choices=["mahalanobis", "ellphi"],
+    )
+    p.add_argument(
+        "--out-base",
+        type=str,
+        default="outputs/backend_compare",
+    )
+    p.add_argument(
+        "--rerun-completed",
+        action="store_true",
+        help=(
+            "Force rerun even when (backend, seed, epochs) already exists in "
+            "progress_summary.csv."
+        ),
+    )
+    return p.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    os.makedirs(args.out_base, exist_ok=True)
+
+    progress_csv = os.path.join(args.out_base, "progress_summary.csv")
+    stats_csv = os.path.join(args.out_base, "backend_stats.csv")
+    ensure_csv_header(
+        progress_csv,
+        PROGRESS_HEADER,
+    )
+
+    done = {
+        (r["backend"], int(r["seed"]), int(r["epochs"]))
+        for r in read_progress(progress_csv)
+    }
+
+    with out_base_lock(args.out_base):
+        for backend in args.backends:
+            for seed in args.seeds:
+                key = (backend, seed, args.epochs)
+                if key in done and not args.rerun_completed:
+                    print(
+                        "[SKIP] already completed "
+                        f"backend={backend} seed={seed} epochs={args.epochs}"
+                    )
+                    continue
+                if key in done and args.rerun_completed:
+                    print(
+                        "[RERUN] existing result found but rerunning due to "
+                        f"--rerun-completed backend={backend} seed={seed} epochs={args.epochs}"
+                    )
+                run_one(
+                    base_config_name=args.base_config,
+                    backend=backend,
+                    seed=seed,
+                    epochs=args.epochs,
+                    out_base=args.out_base,
+                    progress_csv=progress_csv,
+                )
+                write_backend_stats(progress_csv, stats_csv)
+
+    write_backend_stats(progress_csv, stats_csv)
+    print(f"Progress CSV: {progress_csv}")
+    print(f"Backend stats: {stats_csv}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tests/test_run_backend_multiseed.py
+++ b/tests/test_run_backend_multiseed.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import csv
+import math
 import sys
 import tempfile
 import unittest
@@ -52,6 +53,25 @@ class TestRunBackendMultiseed(unittest.TestCase):
             m = rbm.parse_metrics_csv(path)
             self.assertAlmostEqual(m["best_val_recall"], 0.1)
             self.assertAlmostEqual(m["best_val_loss"], 2.0)
+        finally:
+            Path(path).unlink(missing_ok=True)
+
+    def test_parse_metrics_csv_allows_non_finite_val_loss(self) -> None:
+        rows = [
+            {"val_mcc": "0.1", "val_recall": "0.2", "val_loss": "1.0"},
+            {"val_mcc": "0.2", "val_recall": "0.3", "val_loss": "nan"},
+        ]
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+            writer = csv.DictWriter(f, fieldnames=["val_mcc", "val_recall", "val_loss"])
+            writer.writeheader()
+            writer.writerows(rows)
+            path = f.name
+        try:
+            m = rbm.parse_metrics_csv(path)
+            self.assertAlmostEqual(m["best_val_mcc"], 0.2)
+            self.assertAlmostEqual(m["best_val_recall"], 0.3)
+            self.assertTrue(math.isnan(m["best_val_loss"]))
+            self.assertTrue(math.isnan(m["final_val_loss"]))
         finally:
             Path(path).unlink(missing_ok=True)
 

--- a/tests/test_run_backend_multiseed.py
+++ b/tests/test_run_backend_multiseed.py
@@ -1,0 +1,107 @@
+"""Tests for experiments/run_backend_multiseed.py (protocol helpers)."""
+
+from __future__ import annotations
+
+import csv
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_EXPERIMENTS = Path(__file__).resolve().parents[1] / "experiments"
+if str(_EXPERIMENTS) not in sys.path:
+    sys.path.insert(0, str(_EXPERIMENTS))
+
+import run_backend_multiseed as rbm  # noqa: E402
+
+
+class TestRunBackendMultiseed(unittest.TestCase):
+    def test_parse_metrics_csv_best_and_final(self) -> None:
+        rows = [
+            {"val_mcc": "0.1", "val_recall": "0.2", "val_loss": "1.0"},
+            {"val_mcc": "0.5", "val_recall": "0.3", "val_loss": "0.9"},
+            {"val_mcc": "0.4", "val_recall": "0.8", "val_loss": "0.7"},
+        ]
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+            writer = csv.DictWriter(f, fieldnames=["val_mcc", "val_recall", "val_loss"])
+            writer.writeheader()
+            writer.writerows(rows)
+            path = f.name
+        try:
+            m = rbm.parse_metrics_csv(path)
+            self.assertAlmostEqual(m["final_val_mcc"], 0.4)
+            self.assertAlmostEqual(m["final_val_recall"], 0.8)
+            self.assertAlmostEqual(m["final_val_loss"], 0.7)
+            self.assertAlmostEqual(m["best_val_mcc"], 0.5)
+            self.assertAlmostEqual(m["best_val_recall"], 0.3)
+            self.assertAlmostEqual(m["best_val_loss"], 0.9)
+        finally:
+            Path(path).unlink(missing_ok=True)
+
+    def test_parse_metrics_csv_mcc_tie_breaks_on_first_epoch(self) -> None:
+        rows = [
+            {"val_mcc": "0.5", "val_recall": "0.1", "val_loss": "2.0"},
+            {"val_mcc": "0.5", "val_recall": "0.9", "val_loss": "1.0"},
+        ]
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+            writer = csv.DictWriter(f, fieldnames=["val_mcc", "val_recall", "val_loss"])
+            writer.writeheader()
+            writer.writerows(rows)
+            path = f.name
+        try:
+            m = rbm.parse_metrics_csv(path)
+            self.assertAlmostEqual(m["best_val_recall"], 0.1)
+            self.assertAlmostEqual(m["best_val_loss"], 2.0)
+        finally:
+            Path(path).unlink(missing_ok=True)
+
+    def test_sample_std_over_seeds(self) -> None:
+        self.assertEqual(rbm.sample_std_over_seeds([1.0]), 0.0)
+        self.assertAlmostEqual(rbm.sample_std_over_seeds([0.0, 2.0]), 2**0.5)
+
+    def test_write_backend_stats_sample_std(self) -> None:
+        header = rbm.PROGRESS_HEADER
+        rows = [
+            {
+                "backend": "mahalanobis",
+                "seed": "1",
+                "epochs": "50",
+                "run_dir": "/tmp/a",
+                "best_val_mcc": "0.0",
+                "best_val_recall": "0",
+                "best_val_loss": "0",
+                "final_val_mcc": "0.0",
+                "final_val_recall": "0",
+                "final_val_loss": "0",
+            },
+            {
+                "backend": "mahalanobis",
+                "seed": "2",
+                "epochs": "50",
+                "run_dir": "/tmp/b",
+                "best_val_mcc": "2.0",
+                "best_val_recall": "0",
+                "best_val_loss": "0",
+                "final_val_mcc": "2.0",
+                "final_val_recall": "0",
+                "final_val_loss": "0",
+            },
+        ]
+        with tempfile.TemporaryDirectory() as td:
+            progress = Path(td) / "progress_summary.csv"
+            stats = Path(td) / "backend_stats.csv"
+            with progress.open("w", newline="") as f:
+                w = csv.DictWriter(f, fieldnames=header)
+                w.writeheader()
+                w.writerows(rows)
+            rbm.write_backend_stats(str(progress), str(stats))
+            with stats.open(newline="") as f:
+                out = list(csv.reader(f))
+            self.assertEqual(out[0][0], "backend")
+            # mahalanobis, n=2, mean best=1, std_best=sqrt(2), mean final=1, std_final=sqrt(2)
+            self.assertEqual(out[1][0], "mahalanobis")
+            self.assertEqual(out[1][1], "2")
+            self.assertAlmostEqual(float(out[1][2]), 1.0)
+            self.assertAlmostEqual(float(out[1][3]), 2**0.5)
+            self.assertAlmostEqual(float(out[1][4]), 1.0)
+            self.assertAlmostEqual(float(out[1][5]), 2**0.5)


### PR DESCRIPTION
## Summary

- 公式のマルチシード・バックエンド比較入口として `experiments/run_backend_multiseed.py` を追加し、読者向けに `REPRODUCIBILITY.md` と `README.md`（Known Constraints 含む）を整備する。
- `.github/workflows/ruff.yml` に `pytest` と、`run_backend_multiseed.py` の軽量 repro-smoke（1 epoch・seed 1・mahalanobis のみ）を追加し、README / REPRODUCIBILITY の CI 記述と一致させる。

## Depends on

- #57（PR6 がマージされるまで本 PR の差分には PR1〜6 の変更も含まれる。マージ後は `main` に対して PR7 分のみの差分に収束する想定。）

## Test plan

- [x] CI（ruff / pytest / repro-smoke）が緑になる
- [x] ローカルで `uv run pytest` と README の smoke コマンドが通る

Made with [Cursor](https://cursor.com)