### PR TITLE
fix: issue #61 — 対角 self-distance の sqrt NaN 勾配を構造的に修正

### DIFF
--- a/tda_ml/topology.py
+++ b/tda_ml/topology.py
@@ -131,15 +131,12 @@ def _sqrt_off_diagonal_only(dist_sq: torch.Tensor) -> torch.Tensor:
 
     Diagonal squared distances are identically zero (self-distance). Differentiating
     ``sqrt(x)`` at ``x=0`` yields NaN gradients. VR / persistence uses off-diagonal
-    entries only, so diagonals stay zero and ``sqrt`` is applied only to off-diagonal
-    ``dist_sq`` entries (never to the self-distance zeros).
+    entries only, so diagonals stay zero and ``sqrt`` is applied only where
+    ``dist_sq > 0`` (never to zero squared distances, including self-distance and
+    coincident off-diagonal pairs).
     """
     dist_sq = torch.clamp(dist_sq, min=0.0)
     dist = torch.zeros_like(dist_sq)
-    n = dist_sq.shape[-1]
-    offdiag = ~torch.eye(n, device=dist_sq.device, dtype=torch.bool)
-    if dist_sq.ndim == 3:
-        dist[:, offdiag] = torch.sqrt(dist_sq[:, offdiag])
-    else:
-        dist[offdiag] = torch.sqrt(dist_sq[offdiag])
+    positive = dist_sq > 0
+    dist[positive] = torch.sqrt(dist_sq[positive])
     return dist

--- a/tda_ml/topology.py
+++ b/tda_ml/topology.py
@@ -122,5 +122,24 @@ def compute_anisotropic_distance_matrix(
             f"symmetrize must be 'max' or 'min', got {symmetrize!r}"
         )
 
+    return _sqrt_off_diagonal_only(dist_sq)
+
+
+def _sqrt_off_diagonal_only(dist_sq: torch.Tensor) -> torch.Tensor:
+    """
+    Mahalanobis distances with zero diagonal without sqrt backward on self-distances.
+
+    Diagonal squared distances are identically zero (self-distance). Differentiating
+    ``sqrt(x)`` at ``x=0`` yields NaN gradients. VR / persistence uses off-diagonal
+    entries only, so diagonals stay zero and ``sqrt`` is applied only to off-diagonal
+    ``dist_sq`` entries (never to the self-distance zeros).
+    """
     dist_sq = torch.clamp(dist_sq, min=0.0)
-    return torch.sqrt(dist_sq)
+    dist = torch.zeros_like(dist_sq)
+    n = dist_sq.shape[-1]
+    offdiag = ~torch.eye(n, device=dist_sq.device, dtype=torch.bool)
+    if dist_sq.ndim == 3:
+        dist[:, offdiag] = torch.sqrt(dist_sq[:, offdiag])
+    else:
+        dist[offdiag] = torch.sqrt(dist_sq[offdiag])
+    return dist

--- a/tests/test_topology_gradients.py
+++ b/tests/test_topology_gradients.py
@@ -1,0 +1,72 @@
+"""Gradient health for anisotropic distance matrices (issue #61)."""
+
+import torch
+
+from tda_ml.topology import compute_anisotropic_distance_matrix
+
+
+def test_anisotropic_distance_diagonal_is_exactly_zero():
+    batch_size, num_points = 1, 5
+    points = torch.randn(batch_size, num_points, 2, dtype=torch.float32)
+    params = torch.tensor(
+        [
+            [
+                [1.0, 0.5, 0.0],
+                [1.0, 0.5, 0.0],
+                [1.0, 0.5, 0.0],
+                [1.0, 0.5, 0.0],
+                [1.0, 0.5, 0.0],
+            ]
+        ],
+        dtype=torch.float32,
+    )
+    probs = torch.full((batch_size, num_points), 0.2, dtype=torch.float32)
+
+    dist = compute_anisotropic_distance_matrix(
+        points, params, probs=probs, symmetrize="max"
+    )
+    diag = dist.diagonal(dim1=-2, dim2=-1)
+    assert torch.all(diag == 0.0)
+    assert torch.all(dist[..., ~torch.eye(num_points, dtype=torch.bool)] > 0)
+
+
+def test_anisotropic_distance_backward_finite_at_zero_diagonal():
+    """Self-distance diagonal is zero; backward must not emit inf/nan gradients."""
+    batch_size, num_points = 1, 5
+    points = torch.randn(batch_size, num_points, 2, dtype=torch.float32)
+    params = torch.tensor(
+        [
+            [
+                [1.0, 0.5, 0.0],
+                [1.0, 0.5, 0.0],
+                [1.0, 0.5, 0.0],
+                [1.0, 0.5, 0.0],
+                [1.0, 0.5, 0.0],
+            ]
+        ],
+        dtype=torch.float32,
+        requires_grad=True,
+    )
+    probs = torch.full((batch_size, num_points), 0.2, dtype=torch.float32)
+
+    dist = compute_anisotropic_distance_matrix(
+        points, params, probs=probs, symmetrize="max"
+    )
+    assert torch.all(dist.diagonal(dim1=-2, dim2=-1) == 0.0)
+
+    dist.sum().backward()
+    assert params.grad is not None
+    assert torch.isfinite(params.grad).all()
+
+
+def test_anisotropic_distance_backward_no_sqrt_anomaly_on_diagonal():
+    with torch.autograd.detect_anomaly():
+        points = torch.randn(1, 8, 2, dtype=torch.float32, requires_grad=True)
+        params = torch.rand(1, 8, 3, dtype=torch.float32, requires_grad=True)
+        probs = torch.full((1, 8), 0.3, dtype=torch.float32)
+        dist = compute_anisotropic_distance_matrix(
+            points, params, probs=probs, symmetrize="max"
+        )
+        dist.sum().backward()
+    assert torch.isfinite(points.grad).all()
+    assert torch.isfinite(params.grad).all()

--- a/tests/test_topology_gradients.py
+++ b/tests/test_topology_gradients.py
@@ -70,3 +70,46 @@ def test_anisotropic_distance_backward_no_sqrt_anomaly_on_diagonal():
         dist.sum().backward()
     assert torch.isfinite(points.grad).all()
     assert torch.isfinite(params.grad).all()
+
+
+def test_anisotropic_distance_backward_finite_with_coincident_points():
+    """Off-diagonal dist_sq is zero when two centers coincide; backward must stay finite."""
+    points = torch.tensor(
+        [[[0.0, 0.0], [1.0, 0.0], [0.0, 0.0]]],
+        dtype=torch.float32,
+        requires_grad=True,
+    )
+    params = torch.tensor(
+        [[[1.0, 0.5, 0.0], [1.0, 0.5, 0.0], [1.0, 0.5, 0.0]]],
+        dtype=torch.float32,
+        requires_grad=True,
+    )
+
+    dist = compute_anisotropic_distance_matrix(points, params, symmetrize="max")
+    assert dist[0, 0, 2].item() == 0.0
+    assert dist[0, 2, 0].item() == 0.0
+
+    dist.sum().backward()
+    assert torch.isfinite(points.grad).all()
+    assert torch.isfinite(params.grad).all()
+
+
+def test_anisotropic_distance_backward_finite_with_close_points():
+    """Near-coincident pairs have small but positive off-diagonal distances."""
+    base = torch.randn(1, 6, 2, dtype=torch.float32)
+    points = base.clone().requires_grad_(True)
+    with torch.no_grad():
+        points[0, 1] = points[0, 0] + 1e-4
+
+    params = torch.rand(1, 6, 3, dtype=torch.float32, requires_grad=True)
+    probs = torch.full((1, 6), 0.25, dtype=torch.float32)
+
+    dist = compute_anisotropic_distance_matrix(
+        points, params, probs=probs, symmetrize="max"
+    )
+    offdiag = ~torch.eye(6, dtype=torch.bool)
+    assert torch.all(dist[0, offdiag] > 0)
+
+    dist.sum().backward()
+    assert torch.isfinite(points.grad).all()
+    assert torch.isfinite(params.grad).all()


### PR DESCRIPTION
## Summary
- `compute_anisotropic_distance_matrix` で `dist_sq == 0`（対角 self-distance および coincident 点ペア）を `sqrt` の計算グラフから除外し、topo loss 学習時の NaN 勾配崩壊を防ぐ
- ad-hoc eps は追加せず、forward は従来どおり（対角=0、正の非対角は `sqrt(dist_sq)`）
- 対角・anomaly 検出・coincident 点・近接点の勾配健全性テストを追加

Fixes #61

## Test plan
- [x] `uv run pytest tests/test_topology_gradients.py tests/test_topology.py -v`
- [x] `uv run python -m tda_ml.main --config dev`（topo loss 有効、3 epoch NaN なし完走）
- [ ] CI repro-smoke（マージ後）


Made with [Cursor](https://cursor.com)